### PR TITLE
Formular in OXID 6

### DIFF
--- a/copy_this/modules/proudsourcing/psWithdrawalForm/application/controllers/pswithdrawalform.php
+++ b/copy_this/modules/proudsourcing/psWithdrawalForm/application/controllers/pswithdrawalform.php
@@ -128,7 +128,7 @@ class psWithdrawalForm extends oxUBase
     {
         if ( $this->_oCaptcha === null )
         {
-            $this->_oCaptcha = oxNew('oxCaptcha');
+            $this->_oCaptcha = oxNew('oeCaptcha');
         }
         return $this->_oCaptcha;
     }

--- a/copy_this/modules/proudsourcing/psWithdrawalForm/application/controllers/pswithdrawalform.php
+++ b/copy_this/modules/proudsourcing/psWithdrawalForm/application/controllers/pswithdrawalform.php
@@ -132,7 +132,6 @@ class psWithdrawalForm extends oxUBase
         }
         return $this->_oCaptcha;
     }
-
     /**
      * Template variable getter. Returns status if email was send succesfull
      *


### PR DESCRIPTION
 Aufruf des Formulars in OXID 6 verursacht einen Fehler!

> OXID Logger.ERROR: EXCEPTION_SYSTEMCOMPONENT_CLASSNOTFOUND oxcaptcha

Mit dieser Änderung könnte das Modul auch für Version 6 freigegeben werden.
